### PR TITLE
Fix cascading value change when changing charge settings

### DIFF
--- a/src/carconnectivity_connectors/volkswagen/connector.py
+++ b/src/carconnectivity_connectors/volkswagen/connector.py
@@ -1916,10 +1916,8 @@ class Connector(BaseConnector):
                     raise SetterError('Maximum current must be greater than 6 amps')
                 if settings.maximum_current.value < 16:
                     setting_dict['maxChargeCurrentAC'] = 'reduced'
-                    settings.maximum_current.value = 6.0
                 else:
                     setting_dict['maxChargeCurrentAC'] = 'maximum'
-                    settings.maximum_current.value = 16.0
         if isinstance(attribute, BooleanAttribute) and attribute.id == 'auto_unlock':
             setting_dict['autoUnlockPlugWhenChargedAC'] = 'on' if value else 'off'
         elif settings.auto_unlock.enabled and settings.auto_unlock.value is not None:


### PR DESCRIPTION
When changing target_level there is additional logic to fill in setting_dict a value for maximum_current but it also changes the value using the setter which results in a cascading value change that runs this specific on_set_hook twice.

This is unnecessary because the user is changing another attribute so maximum_current can stay as is until it is changed.