### PR TITLE
Call transaction_end() at every update cycle

### DIFF
--- a/src/carconnectivity_connectors/volkswagen/connector.py
+++ b/src/carconnectivity_connectors/volkswagen/connector.py
@@ -256,7 +256,6 @@ class Connector(BaseConnector):
             spin_command.enabled = True
             self.commands.add_command(spin_command)
         self.fetch_vehicles()
-        self.car_connectivity.transaction_end()
 
     def update_vehicles(self) -> None:
         """
@@ -280,6 +279,7 @@ class Connector(BaseConnector):
                 if capability_parking_position is not None and capability_parking_position.enabled and len(capability_parking_position.status.value) == 0:
                     self.fetch_parking_position(vehicle_to_update)
                 self.decide_state(vehicle_to_update)
+        self.car_connectivity.transaction_end()
 
     def fetch_vehicles(self) -> None:
         """


### PR DESCRIPTION
This fixes these issues:
* https://github.com/tillsteinbach/CarConnectivity-plugin-mqtt_homeassistant/issues/39
* https://github.com/tillsteinbach/CarConnectivity-plugin-mqtt_homeassistant/issues/33
* https://github.com/tillsteinbach/CarConnectivity-plugin-mqtt_homeassistant/issues/18

Looking at the git history, it seems this bug was caused by this commit: https://github.com/tillsteinbach/CarConnectivity-connector-volkswagen/commit/6de6020e0e8b00dc6a2b5640e13fc586b8b2c841

Currently, the `self.car_connectivity.transaction_end()` was called at the end of `fetch_all()`, so it triggered only for the initial fetch.

The background loop is calling:
* `fetch_all()` for the first time
* `update_vehicles()` for all the next update cycles

Since `fetch_all()` calls `fetch_vehicles()` anyway, I've moved the `self.car_connectivity.transaction_end()` to the end of `fetch_vehicles()`, so it's called both for initial fetch and next updates.

It's the home assistant plugin who listens on the transaction end events to push the specific mqtt entities for home assistant.