### PR TITLE
Implement token cleanup

### DIFF
--- a/src/carconnectivity_connectors/volkswagen/auth/openid_session.py
+++ b/src/carconnectivity_connectors/volkswagen/auth/openid_session.py
@@ -234,6 +234,22 @@ class OpenIDSession(requests.Session):
             return self._token.get('id_token')
         return None
 
+    @id_token.setter
+    def id_token(self, new_id_token):
+        """
+        Sets a new ID token.
+
+        Args:
+            new_id_token (str): The new ID token to be set. If None, removes the id_token from the token dict.
+        """
+        if self._token is None and new_id_token is not None:
+            self._token = {}
+        if self._token is not None:
+            if new_id_token is None:
+                self._token.pop('id_token', None)
+            else:
+                self._token['id_token'] = new_id_token
+
     @property
     def token_type(self):
         """


### PR DESCRIPTION
Thie PR implements token invalidation and refresh handling in OpenIDSession

I've tried to test this, and this will hopefully fix the issue some users were having with the cache and token files. But I was unable to reproduce this

Sorry for the many changes :(